### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/src/SimpleStack.Orm.MySQLConnector/MySqlConnectorDialectProvider.cs
+++ b/src/SimpleStack.Orm.MySQLConnector/MySqlConnectorDialectProvider.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using Dapper;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using SimpleStack.Orm.MySQL;
 
 namespace SimpleStack.Orm.MySQLConnector

--- a/src/SimpleStack.Orm.MySQLConnector/SimpleStack.Orm.MySQLConnector.csproj
+++ b/src/SimpleStack.Orm.MySQLConnector/SimpleStack.Orm.MySQLConnector.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="0.69.6" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: mysql-net/MySqlConnector#824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.